### PR TITLE
28.8.29.8 - chore: remove push trigger for dev branch from nightly an…

### DIFF
--- a/.github/workflows/dotnet-nightly.yml
+++ b/.github/workflows/dotnet-nightly.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 02:00 UTC
   workflow_dispatch:      # Manual trigger
-  push:
-    branches:
-      - dev
 
 permissions:
   contents: write
@@ -62,12 +59,25 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: dev  # Checkout dev branch specifically
           fetch-depth: 0
 
-      - name: 🔍 Analyze Changes Since Last Nightly
+      - name: 🔍 Verify Branch and Analyze Changes Since Last Nightly
         id: analyze
         run: |
-          echo "🔎 Checking for changes since last nightly release..."
+          echo "🔎 Verifying we're on the dev branch..."
+
+          # Verify we're on the dev branch
+          current_branch=$(git branch --show-current)
+          if [ "$current_branch" != "dev" ]; then
+            echo "⚠️ Not on dev branch (currently on: $current_branch) - skipping nightly build"
+            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "commits-count=wrong-branch" >> $GITHUB_OUTPUT
+            echo "changed-files=not on dev branch" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "✅ Confirmed on dev branch - checking for changes since last nightly release..."
 
           # Get latest nightly release
           latest_nightly=$(gh api repos/${{ github.repository }}/releases --paginate | \

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -2,9 +2,6 @@ name: 🚀 Release Publisher
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - dev
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for nightly and release builds to improve branch handling and workflow triggers. The main focus is to ensure that nightly builds and release publishing are only triggered in appropriate scenarios, and that the nightly workflow always operates on the `dev` branch.

**Workflow trigger and branch handling updates:**

* Removed the `push` trigger for both `.github/workflows/dotnet-nightly.yml` and `.github/workflows/dotnet-release.yml`, so these workflows will no longer run automatically on pushes to the `dev` branch. They are now triggered only by schedule or manual dispatch. [[1]](diffhunk://#diff-0d546c26b6e3b0c8bbc35b4e44a240a76a52097ce28828e70f0e070d89923bbfL7-L9) [[2]](diffhunk://#diff-e6db66c698d5cacbdcef2155b9658f2d7d603f53c2bd5b75217af9b408247962L5-L7)
* Updated the nightly workflow to explicitly check out the `dev` branch and added a verification step to ensure all nightly builds run only when on `dev`. If not on `dev`, the workflow skips the nightly build.