### PR TITLE
Update

### DIFF
--- a/.github/workflows/dotnet-nightly.yml
+++ b/.github/workflows/dotnet-nightly.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 02:00 UTC
   workflow_dispatch:      # Manual trigger
-  push:
-    branches:
-      - dev
 
 permissions:
   contents: write
@@ -62,12 +59,25 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: dev  # Checkout dev branch specifically
           fetch-depth: 0
 
-      - name: 🔍 Analyze Changes Since Last Nightly
+      - name: 🔍 Verify Branch and Analyze Changes Since Last Nightly
         id: analyze
         run: |
-          echo "🔎 Checking for changes since last nightly release..."
+          echo "🔎 Verifying we're on the dev branch..."
+
+          # Verify we're on the dev branch
+          current_branch=$(git branch --show-current)
+          if [ "$current_branch" != "dev" ]; then
+            echo "⚠️ Not on dev branch (currently on: $current_branch) - skipping nightly build"
+            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "commits-count=wrong-branch" >> $GITHUB_OUTPUT
+            echo "changed-files=not on dev branch" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "✅ Confirmed on dev branch - checking for changes since last nightly release..."
 
           # Get latest nightly release
           latest_nightly=$(gh api repos/${{ github.repository }}/releases --paginate | \

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -2,9 +2,6 @@ name: 🚀 Release Publisher
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - dev
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for nightly and release builds to improve branch control and workflow triggers. The main changes ensure that nightly builds only run on the `dev` branch and remove automatic workflow triggers on pushes to `dev`, making the process more intentional and less error-prone.

**Workflow trigger and branch control improvements:**

- Removed the `push` trigger on the `dev` branch from both `.github/workflows/dotnet-nightly.yml` and `.github/workflows/dotnet-release.yml`, so these workflows are no longer automatically triggered by pushes to `dev` and must be run manually or on a schedule. [[1]](diffhunk://#diff-0d546c26b6e3b0c8bbc35b4e44a240a76a52097ce28828e70f0e070d89923bbfL7-L9) [[2]](diffhunk://#diff-e6db66c698d5cacbdcef2155b9658f2d7d603f53c2bd5b75217af9b408247962L5-L7)
- Modified the nightly workflow to explicitly check out the `dev` branch and verify that the workflow is running on `dev` before proceeding, preventing accidental runs on other branches.